### PR TITLE
Add route groups support

### DIFF
--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -50,7 +50,12 @@
       let completeUrl = "";
       let completeRoute =
         relPathToRoutes + (relPathToRoutes.slice(-1) == "/" ? "" : "/");
-      const routes = routeId.split("/").filter((p) => p != "");
+      // Split the route ID on every forward slash, but if there is a group route include that in the
+      // following route. This accounts for the fact that (group) routes do not show up in the path.
+      // For Example:
+      // routeId: test/(group1)/test2/test3
+      // routes: ["test", "(group1)/test2", "test3"]
+      const routes = routeId.split(/(?<!\))\//).filter((p) => p != "");
       const paths = url.pathname.split("/").filter((p) => p != "");
 
       // Loop over each directory in the path and generate a crumb

--- a/src/routes/(group)/groupedRoute/+page.svelte
+++ b/src/routes/(group)/groupedRoute/+page.svelte
@@ -1,0 +1,9 @@
+<script context="module" lang="ts">
+  // You can set the page title with a function that will be given
+  // data from the component in the layout
+  export function getPageTitle(pageData: any) {
+    return "Grouped Page";
+  }
+</script>
+
+Pages within grouped routes can set a page title.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,4 +6,5 @@
   <li>
     <a href="/pageDataExample/metadataExample">Crumb Metadata Example</a>
   </li>
+  <li><a href="/groupedRoute">Route Groups Example</a></li>
 </ul>


### PR DESCRIPTION
Implements and tests the change suggested by @stefanosandes in #10. Route Id regex filter now handles route groups by including it in the following route. 
For Example:

```
routeId: test/(group1)/test2/test3
routes: ["test", "(group1)/test2", "test3"]
```
