### PR TITLE
Account for routes without a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ Page Data to pass through to the `getPageTitle` function living in a route's `pa
 
 A list of `Crumb`s that will override/bypass any breadcrumb generation via routes. In SvelteKit if you pass `$page.data.crumbs` or something similar you will be able to override any bread crumbs via page loads.
 
+#### `shouldSkipCrumbsForRoutesWithNoPage: bool`
+
+> Optional
+
+When set to true, it will completely skip rendering breadcrumbs if there is no page for the route.
+
 #### `titleSanitizer(title: string) -> string`
 
 > Optional

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Page Data to pass through to the `getPageTitle` function living in a route's `pa
 
 A list of `Crumb`s that will override/bypass any breadcrumb generation via routes. In SvelteKit if you pass `$page.data.crumbs` or something similar you will be able to override any bread crumbs via page loads.
 
-#### `shouldSkipCrumbsForRoutesWithNoPage: bool`
+#### `skipRoutesWithNoPage: bool`
 
 > Optional
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-breadcrumbs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run package",

--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -18,7 +18,7 @@
     routeModules?: Record<string, ModuleData>;
     pageData: any;
     children?: Snippet<[any]>;
-    shouldSkipCrumbsForRoutesWithNoPage: boolean;
+    skipRoutesWithNoPage: boolean;
   }
 
   let {
@@ -28,8 +28,8 @@
     crumbs = undefined,
     routeModules = $bindable(undefined),
     pageData,
-    shouldSkipCrumbsForRoutesWithNoPage,
-    children
+    skipRoutesWithNoPage,
+    children,
   }: Props = $props();
 
   onMount(async () => {
@@ -103,8 +103,8 @@
         // Don't show a breadcrumb if there is no page for the route
         if (routeModule == undefined) {
           url = undefined;
-          if (shouldSkipCrumbsForRoutesWithNoPage) {
-            continue
+          if (skipRoutesWithNoPage) {
+            continue;
           }
         }
 
@@ -132,4 +132,4 @@
   });
 </script>
 
-{@render children?.({ crumbs: _crumbs, routeModules, })}
+{@render children?.({ crumbs: _crumbs, routeModules })}

--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -18,6 +18,7 @@
     routeModules?: Record<string, ModuleData>;
     pageData: any;
     children?: Snippet<[any]>;
+    shouldSkipCrumbsForRoutesWithNoPage: boolean;
   }
 
   let {
@@ -27,6 +28,7 @@
     crumbs = undefined,
     routeModules = $bindable(undefined),
     pageData,
+    shouldSkipCrumbsForRoutesWithNoPage,
     children
   }: Props = $props();
 
@@ -91,9 +93,24 @@
             ? undefined
             : routeModules[`${completeRoute}+page.svelte`];
 
+        let url: string | undefined = completeUrl;
+
+        // Don't show a link for the breadcrumb representing the current page
+        if (i == paths.length - 1) {
+          url = undefined;
+        }
+
+        // Don't show a breadcrumb if there is no page for the route
+        if (routeModule == undefined) {
+          url = undefined;
+          if (shouldSkipCrumbsForRoutesWithNoPage) {
+            continue
+          }
+        }
+
         tmpCrumbs.push({
           // Last crumb gets no url as it is the current page
-          url: i == paths.length - 1 ? undefined : completeUrl,
+          url,
           title: getPageTitleFromModule(routeModule) || titleSanitizer(path),
         });
       }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,7 +18,6 @@
   routeId={$page.route.id}
   pageData={$page.data}
   crumbs={pageDataCrumbs}
-  
 >
   {#snippet children({ crumbs })}
     <div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,4 +7,5 @@
     <a href="/pageDataExample/metadataExample">Crumb Metadata Example</a>
   </li>
   <li><a href="/groupedRoute">Route Groups Example</a></li>
+  <li><a href="/blank/skipBlankContent">Skip blank content</a></li>
 </ul>

--- a/src/routes/blank/skipBlankContent/+page.svelte
+++ b/src/routes/blank/skipBlankContent/+page.svelte
@@ -1,0 +1,2 @@
+This is a page to exemplify the ability to skip breadcrumbs that would link to a
+route with no page.


### PR DESCRIPTION
Aims to resolve #15 

This PR adds functionality to account for routes that do not have a page. It now does not show a link for said routes and provides the option to completely skip rendering the breadcrumb for that route.

## Changes
- added test page for inavlid route
- added logic to not show links if there is no page for that route added flag to skip rendering crumbs with no route
- update docs
- bump version