### PR TITLE
Use stricter typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In `+layout.svelte`:
 Add the `Breadcrumbs` component and feed in the current page url
 and the route id via `page` imported from `$app/state`.
 -->
-<Breadcrumbs url={$page.url} routeId={$page.route.id}>
+<Breadcrumbs url={page.url} routeId={page.route.id}>
   {#snippet children({ crumbs })}
     <div>
       <span><a href="/">Home</a></span>
@@ -77,8 +77,8 @@ In the example above, `Breadcrumbs.svelte` will handle grabbing all of the modul
 
 <!-- Note: routeModules and globImportPrefix passed through -->
 <Breadcrumbs
-  url={$page.url}
-  routeId={$page.route.id}
+  url={page.url}
+  routeId={page.route.id}
   {routeModules}
   globImportPrefix={'/src/svelte/'}
   let:crumbs
@@ -94,7 +94,7 @@ The `Breadcrumbs` component will have access to your Svelte components based on 
 - `pageTitle: string`
 - `getPageTitle: (data: PageData) => string`
 
-`getPageTitle` will receive the value of `$page.data` passed through in the `Breadcrumbs` prop. (see the `Breadcrumbs` usage above).
+`getPageTitle` will receive the value of `page.data` passed through in the `Breadcrumbs` prop. (see the `Breadcrumbs` usage above).
 
 Here is an example:
 
@@ -183,13 +183,13 @@ relPathToRoutes + routeId + "/+page.svelte";
 
 > Optional
 
-Route id for the current page. In Sveltekit this is `$page.route.id`.
+Route id for the current page. In SvelteKit this is `page.route.id`.
 
 #### `url: string`
 
 > Required
 
-URL for the current page. Used to generate the url that each breadcrumb should link to when clicked on. In SvelteKit this is `$page.url`.
+URL for the current page. Used to generate the url that each breadcrumb should link to when clicked on. In SvelteKit this is `page.url`.
 
 #### `pageData: PageData`
 
@@ -211,7 +211,7 @@ export function getPageTitle(pageData: PageData) {
 
 > Optional
 
-A list of `Crumb`s that will override/bypass any breadcrumb generation via routes. In SvelteKit if you pass `$page.data.crumbs` or something similar you will be able to override any bread crumbs via page loads.
+A list of `Crumb`s that will override/bypass any breadcrumb generation via routes. In SvelteKit if you pass `page.data.crumbs` or something similar you will be able to override any bread crumbs via page loads.
 
 #### `skipRoutesWithNoPage: bool`
 

--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="Metadata = any">
+<script lang="ts" generics="Metadata = never, PageData = unknown">
   import type { Crumb, ModuleData } from "$lib/types.js";
   import { type Snippet, onMount } from "svelte";
 
@@ -15,9 +15,16 @@
     routeId: string | null;
     url: URL;
     crumbs?: Crumb<Metadata>[];
-    routeModules?: Record<string, ModuleData>;
-    pageData: any;
-    children?: Snippet<[any]>;
+    routeModules?: Record<string, ModuleData<PageData>>;
+    pageData: PageData;
+    children?: Snippet<
+      [
+        {
+          crumbs: Crumb<Metadata>[];
+          routeModules?: Record<string, ModuleData<PageData>>;
+        },
+      ]
+    >;
     skipRoutesWithNoPage?: boolean;
   }
 
@@ -42,7 +49,7 @@
   });
 
   // Given a module and a crumb, determine the page title
-  function getPageTitleFromModule(module: ModuleData | undefined) {
+  function getPageTitleFromModule(module: ModuleData<PageData> | undefined) {
     if (module?.pageTitle) {
       return module.pageTitle;
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,9 @@
-export type Crumb<M = any> = {
+export type Crumb<Metadata = never> = {
   title?: string;
   url?: string;
-  metadata?: M;
+  metadata?: Metadata;
 };
-export type ModuleData = {
+export type ModuleData<PageData = unknown> = {
   pageTitle?: string;
-  getPageTitle?: (data: any) => string;
+  getPageTitle?: (pageData: PageData) => string;
 };

--- a/src/routes/(group)/groupedRoute/+page.svelte
+++ b/src/routes/(group)/groupedRoute/+page.svelte
@@ -1,7 +1,9 @@
 <script module lang="ts">
+  import type { PageData } from "./$types";
+
   // You can set the page title with a function that will be given
   // data from the component in the layout
-  export function getPageTitle(pageData: any) {
+  export function getPageTitle(pageData: PageData) {
     return "Grouped Page";
   }
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
   import type { Crumb } from "$lib";
   import Breadcrumbs from "$lib/components/Breadcrumbs.svelte";
   import type { Snippet } from "svelte";
@@ -10,13 +10,15 @@
 
   let { children }: Props = $props();
 
-  let pageDataCrumbs = $derived($page.data.crumbs as Crumb<MyCrumbMetadata>[] | undefined);
+  let pageDataCrumbs = $derived(
+    page.data.crumbs as Crumb<MyCrumbMetadata>[] | undefined
+  );
 </script>
 
 <Breadcrumbs
-  url={$page.url}
-  routeId={$page.route.id}
-  pageData={$page.data}
+  url={page.url}
+  routeId={page.route.id}
+  pageData={page.data}
   crumbs={pageDataCrumbs}
 >
   {#snippet children({ crumbs })}

--- a/src/routes/todos/[id]/+page.svelte
+++ b/src/routes/todos/[id]/+page.svelte
@@ -1,18 +1,14 @@
 <script module lang="ts">
+  import type { PageData } from "./$types";
   // You can set the page title with a function that will be given
   // data from the component in the layout
-  export function getPageTitle(pageData: any) {
+  export function getPageTitle(pageData: PageData) {
     return pageData?.todo?.name;
   }
 </script>
 
 <script lang="ts">
-  import type { PageData } from "./$types";
-  interface Props {
-    data: PageData;
-  }
-
-  let { data }: Props = $props();
+  let { data } = $props();
   const { todo } = data;
 </script>
 


### PR DESCRIPTION
Get rid of the use of `any` for types that are variable. This increases type safety and provides proper code completion for PageData and Metadata elements in IDEs that support TypeScript.